### PR TITLE
Scrape in parallel + use all grids

### DIFF
--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -48,90 +48,155 @@ export const regions = [
   },
 ];
 
-/// note that this scraper *does not* upload images to hc-cdn.
-/// that's for the differ to do -- that way, we don't perform extra work
-export async function scrape(cookie: string) {
-  const results: Map<number, ShopItem> = new Map();
-  const window = new Window({ url: SOM_URL });
+interface RegionShopItem {
+  title: string;
+  imageUrl?: string;
+  description?: string;
+  price: number;
+  purchaseUrl: string;
+  id: number;
+  stockRemaining?: number;
+  regionCode: string;
+}
 
-  for (const region of regions) {
-    const response = await fetch(`${SOM_URL}?region=${region.code}`, {
+async function scrapeRegion(regionCode: string, cookie: string): Promise<RegionShopItem[]> {
+  const window = new Window({ url: SOM_URL });
+  const regionItems: RegionShopItem[] = [];
+
+  try {
+    const response = await fetch(`${SOM_URL}?region=${regionCode}`, {
       headers: {
         Cookie: cookie,
-        "User-Agent": "The Summer of Making Monitor starts now! The premise is simple: scrape stuff, ping stuff! Your job is to send me the shop items you have available to peruse. Tell the story of your items with updates on your shop page. One you're done, your shop item update goes to head-to-head #meta match ups voted on by the community. The more votes you get, the less likely Hack Club gets cancelled! You can spend shells on rewards in the shop. We're giving away shells, orders, users, everything you need to keep building. Update stuff, get stuff. Repeat until the summer ends on August 31st. This summer is yours for the making, get started at go.skyfall.dev/som-monitor. For teenagers 18 or under."
+        "User-Agent":
+          "The Summer of Making Monitor starts now! The premise is simple: scrape stuff, ping stuff! Your job is to send me the shop items you have available to peruse. Tell the story of your items with updates on your shop page. One you're done, your shop item update goes to head-to-head #meta match ups voted on by the community. The more votes you get, the less likely Hack Club gets cancelled! You can spend shells on rewards in the shop. We're giving away shells, orders, users, everything you need to keep building. Update stuff, get stuff. Repeat until the summer ends on August 31st. This summer is yours for the making, get started at go.skyfall.dev/som-monitor. For teenagers 18 or under.",
       },
     });
+
     const document = window.document;
     document.body.innerHTML = await response.text();
-    const grid = document.querySelector(".sm\\:grid");
-    if (!grid) {
+    const grids = document.querySelectorAll(".sm\\:grid");
+    
+    if (grids.length === 0) {
       throw new Error(
-        `Grid element not found whilst looking at items for ${region.code}`
+        `Grid elements not found whilst looking at items for ${regionCode}`,
       );
     }
 
-    for (const child of grid.children) {
-      const title = child.querySelector("h3")?.textContent.trim()!;
-      const imageUrl = (
-        child.querySelector("img.rounded-lg") as unknown as
-          | HTMLImageElement
-          | undefined
-      )?.src.trim();
-      const description = child
-        .querySelector("div.mb-4 > p.text-gray-700")
-        ?.textContent?.trim();
-      const priceEl = child
-        .querySelector(
-          "div.absolute.top-2.right-2.text-lg.font-bold.whitespace-nowrap.flex.items-center > picture"
-        )
-        ?.parentElement?.textContent.trim()
-        .replaceAll(",", "");
-      if (!priceEl)
-        throw new Error(
-          "Price element not found. Has the shop page code updated?"
-        );
-      const price = Number(priceEl) || 0;
-      const purchaseUrl = child.querySelector("form")?.action.trim()!;
-      const id = Number(purchaseUrl.replace(/[^0-9]/g, ""));
+    for (const grid of grids) {
+      for (const child of grid.children) {
+        const title = child.querySelector("h3")?.textContent?.trim();
+        if (!title) continue;
 
-      const isOutOfStock = !!child.querySelector("p.text-red-600");
-      const limitedStockRemainingText = child
-        .querySelector("p.text-orange-600")
-        ?.textContent?.replace(/[^0-9]/g, "");
-      const limitedStockRemaining = limitedStockRemainingText
-        ? Number(limitedStockRemainingText)
-        : undefined;
+        const imageUrl = (
+          child.querySelector("img.rounded-lg") as unknown as
+            | HTMLImageElement
+            | undefined
+        )?.src?.trim();
+        
+        const description = child
+          .querySelector("div.mb-4 > p.text-gray-700")
+          ?.textContent?.trim();
+        
+        const priceEl = child
+          .querySelector(
+            "div.absolute.top-2.right-2.text-lg.font-bold.whitespace-nowrap.flex.items-center > picture",
+          )
+          ?.parentElement?.textContent?.trim()
+          ?.replaceAll(",", "");
+        
+        if (!priceEl) {
+          throw new Error(
+            `Price element not found for region ${regionCode}. Has the shop page code updated?`,
+          );
+        }
+        
+        const price = Number(priceEl) || 0;
+        const purchaseUrl = child.querySelector("form")?.action?.trim();
+        if (!purchaseUrl) continue;
+        
+        const id = Number(purchaseUrl.replace(/[^0-9]/g, ""));
 
-      if (results.has(id)) {
-        const prev = results.get(id)!;
-        results.set(id, {
-          ...prev,
-          prices: {
-            ...prev.prices,
-            [region.code]: price,
-          },
-        });
-      } else {
-        results.set(id, {
+        const isOutOfStock = !!child.querySelector("p.text-red-600");
+        const limitedStockRemainingText = child
+          .querySelector("p.text-orange-600")
+          ?.textContent?.replace(/[^0-9]/g, "");
+        const limitedStockRemaining = limitedStockRemainingText
+          ? Number(limitedStockRemainingText)
+          : undefined;
+
+        regionItems.push({
           title,
           imageUrl,
           description,
-          prices: {
-            [region.code]: price,
-          },
+          price,
           purchaseUrl,
           id,
           stockRemaining: isOutOfStock ? 0 : limitedStockRemaining,
+          regionCode,
         });
       }
     }
+  } catch (error) {
+    console.error(`Error scraping region ${regionCode}:`, error);
+    throw error;
   }
 
-  const shopItems = ShopItems(Array.from(results.values()));
-  if (shopItems instanceof type.errors) {
-    throw new Error(shopItems.summary);
+  return regionItems;
+}
+
+function mergeRegionItems(allRegionItems: RegionShopItem[]): Map<number, ShopItem> {
+  const results = new Map<number, ShopItem>();
+
+  for (const item of allRegionItems) {
+    const { regionCode, price, ...itemData } = item;
+    
+    if (results.has(item.id)) {
+      const existing = results.get(item.id)!;
+      // merge prices from different regions
+      results.set(item.id, {
+        ...existing,
+        prices: {
+          ...existing.prices,
+          [regionCode]: price,
+        },
+      });
+    } else {
+      results.set(item.id, {
+        ...itemData,
+        prices: {
+          [regionCode]: price,
+        },
+      });
+    }
   }
 
-  console.log(`🎉 Found ${shopItems.length} items.`);
-  return shopItems;
+  return results;
+}
+
+/// note that this scraper *does not* upload images to hc-cdn.
+/// that's for the differ to do -- that way, we don't perform extra work
+export async function scrape(cookie: string): Promise<ShopItems> {
+  // Scrape all regions in parallel
+  const regionPromises = regions.map(region => 
+    scrapeRegion(region.code, cookie)
+  );
+
+  try {
+    const allRegionResults = await Promise.all(regionPromises);
+    const allRegionItems = allRegionResults.flat();
+    
+    // merge items by ID, combining prices from all the different regions
+    const results = mergeRegionItems(allRegionItems);
+    
+    const shopItems = ShopItems(Array.from(results.values()));
+    if (shopItems instanceof type.errors) {
+      throw new Error(shopItems.summary);
+    }
+
+    console.log(`🎉 Found ${shopItems.length} items across ${regions.length} regions.`);
+    return shopItems;
+  } catch (error) {
+    console.error('Error during parallel scraping:', error);
+    throw error;
+  }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
The scraper now fetches shop items from all regions in parallel and collects items from every grid on the page, making the process faster and more reliable.

- **Refactors**
  - Runs region scrapes in parallel instead of sequentially.
  - Merges items from all grids and regions, combining prices by region.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and reliability of shop data retrieval by enabling parallel fetching across regions.
  * Enhanced error handling and logging for better transparency during data collection.

* **Bug Fixes**
  * Resolved issues with missing or incomplete item data when fetching from multiple regions.

* **New Features**
  * Shop items now display merged price and stock information from all supported regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->