### PR TITLE
Stop clogging up the som-monitor channel whenever an imageHash changes

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,3 +1,0 @@
-differences
-<img width="1652" height="558" alt="image" src="https://github.com/user-attachments/assets/41ed6b23-3cb0-4abe-a30b-3095984031de" />
-<img width="884" height="613" alt="image" src="https://github.com/user-attachments/assets/334cd80b-76dc-4005-bb32-9636664f665e" />

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,3 @@
+differences
+<img width="1652" height="558" alt="image" src="https://github.com/user-attachments/assets/41ed6b23-3cb0-4abe-a30b-3095984031de" />
+<img width="884" height="613" alt="image" src="https://github.com/user-attachments/assets/334cd80b-76dc-4005-bb32-9636664f665e" />

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,8 +177,16 @@ function isItemFree(item: ShopItem): boolean {
   return prices.length > 0 && prices.every(price => price === 0);
 }
 
+function itemsEqualWithoutImageHash(oldItem: ShopItem, newItem: ShopItem): boolean {
+  const oldCopy = { ...oldItem };
+  const newCopy = { ...newItem };
+  delete oldCopy.imageHash;
+  delete newCopy.imageHash;
+  return deepEquals(oldCopy, newCopy);
+}
+
 function shouldNotifyChannel(oldItem: ShopItem, newItem: ShopItem): boolean {
-  const ignoreKeys = ["title", "description"];
+  const ignoreKeys = ["title", "description", "imageHash"];
   const importantChange = Object.keys(newItem).some((key) => {
     if (ignoreKeys.includes(key)) return false;
     const oldVal = (oldItem as any)[key];
@@ -239,7 +247,7 @@ async function run() {
         continue;
       }
 
-      if (deepEquals(oldItem, currentItem)) {
+      if (itemsEqualWithoutImageHash(oldItem, currentItem)) {
         continue;
       } else {
         console.log("diff!!", JSON.stringify(oldItem), JSON.stringify(currentItem));


### PR DESCRIPTION
This PR makes it so that a message isn't sent by Traveller when just the image hash is updated, which has the side affect of not showing changes in images, however it prevents the #som-monitor channel from getting clogged up by like 10 messages a day

Right now, Traveller sends an update whenever the `imageHash` value changes for an item. However almost all of the time, the image doesn't actually change and instead the hash is added or removed. This could be a result of the cdn timing out so the hash is blank, and when the cron job next runs and a hash is actually generated, Traveller sends another message (this is consistent with how there are always 2 messages sent a minute after each other as seen below)

<img width="200" height="auto" alt="image" src="https://github.com/user-attachments/assets/7a61b13f-77a3-4a78-aba8-bfd2b2eaf48f" />

<br />
<br />
<br />

TLDR: This PR makes it so that a message isn't sent by Traveller when **only** the image hash is updated

<br />

More examples of differences in the imageHash:
<br />
<img width="1000" height="auto" alt="image" src="https://github.com/user-attachments/assets/41ed6b23-3cb0-4abe-a30b-3095984031de" />
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/334cd80b-76dc-4005-bb32-9636664f665e" />
